### PR TITLE
remove a bunch of duplicate flags and use real <a> tags

### DIFF
--- a/filamentcolors/appstatic/css/main.css
+++ b/filamentcolors/appstatic/css/main.css
@@ -1,5 +1,15 @@
 @import url("https://fonts.googleapis.com/icon?family=Material+Icons");
 
+html {
+    scroll-behavior: smooth;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    html {
+        scroll-behavior: auto;
+    }
+}
+
 body {
     color: black;
     /*background: #eaeaea;*/

--- a/filamentcolors/templates/base.html
+++ b/filamentcolors/templates/base.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     {% include 'partials/head.partial' %}
     {% if swatch %}
@@ -11,7 +11,13 @@
     {% endif %}
 </head>
 
-<body>
+<body
+        hx-target="#main"
+        hx-boost="true"  {# Make all <a> tags htmx-compatible. #}
+        hx-swap="outerHTML"  {# Always swap the full element and the target. #}
+        hx-push-url="true" {# Update the URL that displays in the browser. #}
+        hx-indicator="#loading" {# The location of the loading spinner. #}
+>
 {% include 'partials/navbar.partial' %}
 
 {% if launch_welcome_modal %}

--- a/filamentcolors/templates/partials/card.partial
+++ b/filamentcolors/templates/partials/card.partial
@@ -1,19 +1,13 @@
 {% load static %}
 
-<button
+<div
         id="s{{ obj.id }}"
         class="card mb-4 shadow swatchcard cardBox anim mx-auto"
         style="width: 18rem;"
         data-swatch-id="{{ obj.id }}"
 >
     <div class="card-img-overlay p-0"></div>
-    <div hx-target="#main"
-         hx-swap="outerHTML"
-         hx-trigger="click"
-         hx-get="/swatch/{{ obj.id }}"
-         hx-push-url="true"
-         hx-indicator="#loading">
-
+    <a href="/swatch/{{ obj.id }}">
         <div class="card-img-container">
             <img class="card-img-top img-fluid layer lazy-load-image"
                  src="{% static 'swatch-card-test.svg' %}"
@@ -46,5 +40,5 @@
             </div>
             <p class="card-text">{{ obj.manufacturer.name }} - {{ obj.color_name }} {{ obj.filament_type.name }}</p>
         </div>
-    </div>
-</button>
+    </a>
+</div>

--- a/filamentcolors/templates/partials/colormatch_results.partial
+++ b/filamentcolors/templates/partials/colormatch_results.partial
@@ -11,9 +11,7 @@
                             class="btn bg-gradient-info"
                             hx-target="#saved_swatches_collection"
                             hx-swap="beforeend"
-                            hx-trigger="click"
-                            hx-get="/single_swatch_card/{{ option.id }}"
-                            hx-indicator="#loading"
+                            href="/single_swatch_card/{{ option.id }}"
                     >Grab Swatch</a>
                 </div>
             </div>

--- a/filamentcolors/templates/partials/footer.partial
+++ b/filamentcolors/templates/partials/footer.partial
@@ -7,13 +7,10 @@
         <div class="row">
             <div class="col-sm-2"></div>
             <div class="col-1 col-sm-2 text-center bump-down mx-auto">
-                <button tabindex="0"
+                <a tabindex="0"
                         hx-target="#main"
-                        hx-swap="outerHTML"
                         hx-trigger="click"
-                        hx-get="{% url 'about' %}"
-                        hx-indicator="#loading"
-                        hx-push-url="true"
+                        href="{% url 'about' %}"
                         class="btn-invisible"
                 >
                     <img title="About this site!"
@@ -21,7 +18,7 @@
                          loading="lazy"
                          alt="about this site"
                          src="{% static 'help_icon.png' %}">
-                </button>
+                </a>
             </div>
             <div class="col-1 col-sm-2 text-center bump-down mx-auto">
                 <a href="https://github.com/itsthejoker/filamentcolors.xyz" target="_blank" rel="noopener">

--- a/filamentcolors/templates/partials/head.partial
+++ b/filamentcolors/templates/partials/head.partial
@@ -51,11 +51,6 @@
 
 <script>
     htmx.onLoad(function (t) {
-        // scroll to the top of a page loaded via htmx, but don't scroll on any other type of load
-        if (!(document.getElementById("noScrollToTop"))) {
-            window.scrollTo(0, 0);
-        }
-
         tooltips();
         lazyloadimages();
 
@@ -99,7 +94,7 @@
         const tooltipList = [...tooltipTriggerList].map(tooltipTriggerEl => new bootstrap.Tooltip(tooltipTriggerEl))
     }
 
-    htmx.config.historyCacheSize = 1;
+    htmx.config.historyCacheSize = 10;
     htmx.config.refreshOnHistoryMiss = true
     htmx.config.useTemplateFragments = true
 

--- a/filamentcolors/templates/partials/navbar.partial
+++ b/filamentcolors/templates/partials/navbar.partial
@@ -4,16 +4,11 @@
         class="navbar navbar-expand-lg navbar-light bg-white z-index-3 py-3">
     <div class="container">
         <a class="navbar-brand d-md-block d-lg-none"
-           hx-get="{% url 'library' %}"
+           href="{% url 'library' %}"
            rel="tooltip"
            title="Colors for everybody!"
            data-bs-placement="bottom"
            tabindex="0"
-           hx-indicator="#loading"
-           hx-target="#main"
-           hx-swap="outerHTML"
-           hx-trigger="click"
-           hx-push-url="true"
         >
             FilamentColors.xyz
         </a>
@@ -30,13 +25,8 @@
             <ul class="navbar-nav d-md-none d-lg-block">
                 <li>
                     <a class="navbar-brand clickable"
-                       hx-get="{% url 'library' %}"
-                       hx-indicator="#loading"
+                       href="{% url 'library' %}"
                        tabindex="0"
-                       hx-target="#main"
-                       hx-swap="outerHTML"
-                       hx-trigger="click"
-                       hx-push-url="true"
                     >
                         FilamentColors.xyz
                     </a>
@@ -58,15 +48,10 @@
                         <div class="d-none d-lg-block">
                             <ul class="list-group">
                                 <li class="nav-item dropdown dropdown-hover dropdown-subitem list-group-item border-0 p-0">
-                                    <button
+                                    <a
                                             class="dropdown-item py-2 ps-3 border-radius-md"
                                             tabindex="0"
-                                            hx-target="#main"
-                                            hx-swap="outerHTML"
-                                            hx-trigger="click"
-                                            hx-get="{% url 'mfr_list' %}"
-                                            hx-indicator="#loading"
-                                            hx-push-url="true"
+                                            href="{% url 'mfr_list' %}"
                                     >
                                         <div class="d-flex">
                                             <div class="w-100 d-flex align-items-center justify-content-between">
@@ -80,27 +65,17 @@
                                                      class="arrow">
                                             </div>
                                         </div>
-                                    </button>
+                                    </a>
                                     <div class="dropdown-menu mt-0 py-3 px-2 mt-3">
                                         {% for m in manufacturers|slice:"9" %}
                                             <a class="dropdown-item ps-3 border-radius-md mb-1"
                                                tabindex="0"
-                                               hx-target="#main"
-                                               hx-swap="outerHTML"
-                                               hx-trigger="click"
-                                               hx-get="/library/manufacturer/{{ m.id }}"
-                                               hx-indicator="#loading"
-                                               hx-push-url="true"
+                                               href="/library/manufacturer/{{ m.id }}"
                                             >{{ m.name }}</a>
                                         {% endfor %}
                                         <a class="dropdown-item ps-3 border-radius-md mb-1"
                                            tabindex="0"
-                                           hx-target="#main"
-                                           hx-swap="outerHTML"
-                                           hx-trigger="click"
-                                           hx-get="{% url 'mfr_list' %}"
-                                           hx-indicator="#loading"
-                                           hx-push-url="true"
+                                           href="{% url 'mfr_list' %}"
                                         ><strong>→ view all</strong></a>
                                     </div>
                                 </li>
@@ -122,12 +97,7 @@
                                         {% for t in filament_types %}
                                             <a class="dropdown-item ps-3 border-radius-md mb-1"
                                                tabindex="0"
-                                               hx-target="#main"
-                                               hx-swap="outerHTML"
-                                               hx-trigger="click"
-                                               hx-push-url="true"
-                                               hx-get="/library/filament_type/{{ t.id }}"
-                                               hx-indicator="#loading"
+                                               href="/library/filament_type/{{ t.id }}"
                                             >{{ t.name }}</a>
                                         {% endfor %}
                                     </div>
@@ -150,35 +120,20 @@
                                         {% for c in color_family %}
                                             <a class="dropdown-item ps-3 border-radius-md mb-1"
                                                tabindex="0"
-                                               hx-target="#main"
-                                               hx-swap="outerHTML"
-                                               hx-trigger="click"
-                                               hx-push-url="true"
-                                               hx-indicator="#loading"
-                                               hx-get="/library/color_family/{{ c.0 }}">{{ c.1 }}</a>
+                                               href="/library/color_family/{{ c.0 }}">{{ c.1 }}</a>
                                         {% endfor %}
                                     </div>
                                 </li>
                                 <li class="nav-item list-group-item border-0 p-0">
-                                    <a hx-get="/library/sort/random"
+                                    <a href="/library/sort/random"
                                        tabindex="0"
-                                       hx-target="#main"
-                                       hx-swap="outerHTML"
-                                       hx-indicator="#loading"
-                                       hx-trigger="click"
-                                       hx-push-url="true"
                                        class="dropdown-item border-radius-md text-dark ps-3 d-flex align-items-center mb-1">
                                         <b>Random</b>
                                     </a>
                                 </li>
                                 <li class="nav-item list-group-item border-0 p-0">
-                                    <a hx-get="/library/sort/color"
+                                    <a href="/library/sort/color"
                                        tabindex="0"
-                                       hx-indicator="#loading"
-                                       hx-target="#main"
-                                       hx-swap="outerHTML"
-                                       hx-trigger="click"
-                                       hx-push-url="true"
                                        class="dropdown-item border-radius-md text-dark ps-3 d-flex align-items-center mb-1">
                                         <b>Color</b>
                                     </a>
@@ -265,13 +220,8 @@
                         <div class="d-none d-lg-block">
                             <ul class="list-group">
                                 <li class="nav-item list-group-item border-0 p-0">
-                                    <a hx-get="{% url 'about' %}"
+                                    <a href="{% url 'about' %}"
                                        tabindex="0"
-                                       hx-indicator="#loading"
-                                       hx-target="#main"
-                                       hx-swap="outerHTML"
-                                       hx-trigger="click"
-                                       hx-push-url="true"
                                        class="dropdown-item border-radius-md text-dark ps-3 d-flex align-items-center mb-1">
                                         <b>The project</b>
                                     </a>
@@ -336,13 +286,8 @@
                         <div class="d-none d-lg-block">
                             <ul class="list-group">
                                 <li class="nav-item list-group-item border-0 p-0">
-                                    <a hx-get="{% url 'donations' %}"
+                                    <a href="{% url 'donations' %}"
                                        tabindex="0"
-                                       hx-target="#main"
-                                       hx-indicator="#loading"
-                                       hx-swap="outerHTML"
-                                       hx-trigger="click"
-                                       hx-push-url="true"
                                        class="dropdown-item border-radius-md text-dark ps-3 d-flex align-items-center mb-1">
                                         <b>Filament donations</b>
                                     </a>
@@ -417,13 +362,8 @@
                 <li class="mx-2">
                     <a class="nav-link d-flex justify-content-between cursor-pointer align-items-center"
                        role="button"
-                       hx-get="{% url 'colormatch' %}"
+                       href="{% url 'colormatch' %}"
                        tabindex="0"
-                       hx-target="#main"
-                       hx-indicator="#loading"
-                       hx-swap="outerHTML"
-                       hx-trigger="click"
-                       hx-push-url="true"
                     >
                         Color Match
                     </a>
@@ -446,49 +386,29 @@
                             <div class="d-none d-lg-block">
                                 <ul class="list-group">
                                     <li class="nav-item list-group-item border-0 p-0">
-                                        <a hx-get="{% url 'add_swatch_landing' %}"
+                                        <a href="{% url 'add_swatch_landing' %}"
                                            tabindex="0"
-                                           hx-indicator="#loading"
-                                           hx-target="#main"
-                                           hx-swap="outerHTML"
-                                           hx-trigger="click"
-                                           hx-push-url="true"
                                            class="dropdown-item border-radius-md text-dark ps-3 d-flex align-items-center mb-1">
                                             <b>Upload New</b>
                                         </a>
                                     </li>
                                     <li class="nav-item list-group-item border-0 p-0">
-                                        <a hx-get="{% url 'add_mfr' %}"
+                                        <a href="{% url 'add_mfr' %}"
                                            tabindex="0"
-                                           hx-indicator="#loading"
-                                           hx-target="#main"
-                                           hx-swap="outerHTML"
-                                           hx-trigger="click"
-                                           hx-push-url="true"
                                            class="dropdown-item border-radius-md text-dark ps-3 d-flex align-items-center mb-1">
                                             <b>Add Manufacturer</b>
                                         </a>
                                     </li>
                                     <li class="nav-item list-group-item border-0 p-0">
-                                        <a hx-get="{% url 'add_filament_type' %}"
+                                        <a href="{% url 'add_filament_type' %}"
                                            tabindex="0"
-                                           hx-indicator="#loading"
-                                           hx-target="#main"
-                                           hx-swap="outerHTML"
-                                           hx-trigger="click"
-                                           hx-push-url="true"
                                            class="dropdown-item border-radius-md text-dark ps-3 d-flex align-items-center mb-1">
                                             <b>Add Filament Type</b>
                                         </a>
                                     </li>
                                     <li class="nav-item list-group-item border-0 p-0">
-                                        <a hx-get="{% url 'set_colors' %}"
+                                        <a href="{% url 'set_colors' %}"
                                            tabindex="0"
-                                           hx-indicator="#loading"
-                                           hx-target="#main"
-                                           hx-swap="outerHTML"
-                                           hx-trigger="click"
-                                           hx-push-url="true"
                                            class="dropdown-item border-radius-md text-dark ps-3 d-flex align-items-center mb-1">
                                             <b>Set Hex Colors</b>
                                         </a>

--- a/filamentcolors/templates/standalone/donations.html
+++ b/filamentcolors/templates/standalone/donations.html
@@ -27,16 +27,8 @@
             library! If you have any questions, give me a shout!
         </p>
         <div class="row mt-4 mb-3">
-            <div
-                    class="col-sm-12 col-md-4 mx-auto d-grid"
-                    hx-target="#main"
-                    hx-swap="outerHTML"
-                    hx-trigger="click"
-                    hx-get="{% url 'inventory' %}"
-                    hx-push-url="true"
-                    hx-indicator="#loading"
-            >
-                <div class="btn btn-lg bg-gradient-primary">Inventory</div>
+            <div class="col-sm-12 col-md-4 mx-auto d-grid">
+                <a class="btn btn-lg bg-gradient-primary" href="{% url 'inventory' %}">Inventory</a>
             </div>
         </div>
         <h2>Supplies Needed</h2>
@@ -154,9 +146,9 @@
             <div class="alert alert-primary text-white" role="alert">
                 If it would be cheaper for you to ship to Europe, FilamentColors.xyz has
                 partnered with
-                <a class="alert-link text-white" href="https://www.3dgeeks.app">3D Geeks App</a>
+                <a class="alert-link text-white" href="https://www.3dgeeks.app" target="_blank">3D Geeks App</a>
                 in the Netherlands to serve as an alternate shipping destination. Hop in
-                the <a class="alert-link text-white" href="https://www.3dgeeks.app/u/discord-server">
+                the <a class="alert-link text-white" href="https://www.3dgeeks.app/u/discord-server" target="_blank">
                 3D Geeks Discord</a> and ask for <b>@Toby</b> for additional information!
             </div>
         </div>

--- a/filamentcolors/templates/standalone/manufacturer_list.html
+++ b/filamentcolors/templates/standalone/manufacturer_list.html
@@ -34,12 +34,7 @@
                     <a
                             type="button"
                             class="btn btn-default mfr-btn"
-                            hx-target="#main"
-                            hx-swap="outerHTML"
-                            hx-trigger="click"
-                            hx-get="{% url 'manufacturersort' m.id %}"
-                            hx-push-url="true"
-                            hx-indicator="#loading"
+                            href="{% url 'manufacturersort' m.id %}"
                     >
                         <span>{{ m }}</span>
                         <span class="badge badge-primary">{{ m.swatch_count }}</span>

--- a/filamentcolors/templates/standalone/swatch_detail.html
+++ b/filamentcolors/templates/standalone/swatch_detail.html
@@ -28,7 +28,7 @@
         {% if not error %}
             <div class="row">
                 <div class="col-lg-6">
-                    <section class="gallery-block grid-gallery">
+                    <section class="gallery-block grid-gallery" hx-boost="false">
                         <div class="item">
                             <a class="lightbox" href="{{ swatch.image_front.url }}"
                                title="Representative picture of the swatch front">
@@ -145,24 +145,14 @@
                                             <li>
                                                 <a class="dropdown-item"
                                                    tabindex="0"
-                                                   hx-target="#main"
-                                                   hx-indicator="#loading"
-                                                   hx-swap="outerHTML"
-                                                   hx-trigger="click"
-                                                   hx-push-url="true"
-                                                   hx-get="{% url 'update_images' swatch.id %}">
+                                                   href="{% url 'update_images' swatch.id %}">
                                                     Replace Images
                                                 </a>
                                             </li>
                                             <li>
                                                 <a class="dropdown-item"
                                                    tabindex="0"
-                                                   hx-target="#main"
-                                                   hx-indicator="#loading"
-                                                   hx-swap="outerHTML"
-                                                   hx-trigger="click"
-                                                   hx-push-url="true"
-                                                   hx-get="{% url 'force_hex_color' swatch.id %}">
+                                                   href="{% url 'force_hex_color' swatch.id %}">
                                                     Force Specific Color
                                                 </a>
                                             </li>

--- a/filamentcolors/templates/standalone/update_swatch_colors.html
+++ b/filamentcolors/templates/standalone/update_swatch_colors.html
@@ -42,14 +42,13 @@
                                     <input type="text" style="display: none" value="{{ s.id }}" name="swatch_id">
                                 </div>
                                 <div class="col-lg-6 d-grid">
-                                    <button
+                                    <a
                                             class="btn bg-gradient-secondary"
                                             hx-post="{% url 'set_colors' %}"
-                                            hx-trigger="click"
                                             hx-target="#row-{{ s.id }}"
                                             hx-swap="innerHTML"
                                     >Submit
-                                    </button>
+                                    </a>
                                 </div>
                             </div>
                         </form>


### PR DESCRIPTION
Turns out that most HTMX flags filter downwards from parent elements, so I didn't actually have to declare these every time. Hooray for cleaning up extra code!