### PR TITLE
fix `window.picker` not being ready before use

### DIFF
--- a/filamentcolors/templates/partials/head.partial
+++ b/filamentcolors/templates/partials/head.partial
@@ -33,7 +33,7 @@
 <script src="{% static 'vendored/js/bootstrap.bundle.min.js' %}"></script>
 <script src="{% static 'vendored/js/masonry.min.js' %}"></script>
 <script src="{% static 'vendored/js/long_press.js' %}" async defer></script>
-<script src="{% static 'vendored/js/jscolor.min.js' %}" async></script>
+<script src="{% static 'vendored/js/jscolor.min.js' %}"></script>
 <script src="{% static 'vendored/js/color.global.min.js' %}"></script>
 <script src="{% static 'vendored/js/sortable.min.js' %}"></script>
 <script src="{% static 'vendored/js/jquery-sortable.js' %}"></script>


### PR DESCRIPTION
Removes `async` from the JSColor script tag. Since `colormatch.js` (loaded with defer) depends on JSColor being available, JSColor needs to load synchronously first. With async, there was a race condition where the component's `_onLoad` would try to create `new JSColor(...)`, fail silently, leave `window.picker` as undefined, and then every subsequent call to `window.picker.fromString()` or `window.picker.toHEXString()` would throw.